### PR TITLE
set maxLines in password fields to 1

### DIFF
--- a/lib/screens/account_setup_screen.dart
+++ b/lib/screens/account_setup_screen.dart
@@ -106,6 +106,7 @@ class _AccountSetupScreenState extends State<AccountSetupScreen> {
         onSaved: (value) {},
         validatorCondition: (value) => value.isEmpty,
         controller: _passwordController,
+        maxLines: 1,
         obscureText: true);
   }
 

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -90,6 +90,7 @@ class _LoginScreenState extends State<LoginScreen> {
         onSaved: (value) {},
         validatorCondition: (value) => value.isEmpty,
         controller: _passwordController,
+        maxLines: 1,
         obscureText: true);
   }
 


### PR DESCRIPTION
Set maxLines in password field widgets to 1.
Flutter tester started complaining about this and aborting login after maxLines was added as a parameter to the standarInputBoxWithoutFlex widget.