### PR TITLE
news feed editing

### DIFF
--- a/lib/models/news_item.dart
+++ b/lib/models/news_item.dart
@@ -1,13 +1,15 @@
 class NewsItem {
+  String docID;
   String imageUrl;
   String title;
   String body;
   DateTime date;
 
-  NewsItem({this.imageUrl, this.title, this.body, this.date});
+  NewsItem({this.docID, this.imageUrl, this.title, this.body, this.date});
 
   factory NewsItem.fromJSON(Map<String, dynamic> json) {
     return NewsItem(
+      docID: json['docID'],
       imageUrl: json['imageUrl'],
       title: json['title'],
       body: json['body'],
@@ -16,6 +18,7 @@ class NewsItem {
   }
 
   NewsItem.fromMap(Map<String, dynamic> info) {
+    this.docID = info['docID'];
     this.imageUrl = info['imageUrl'];
     this.title = info['title'];
     this.body = info['body'];

--- a/lib/screens/news_screen.dart
+++ b/lib/screens/news_screen.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:pet_matcher/screens/add_news_item_screen.dart';
 import 'package:share/share.dart';
 import 'package:pet_matcher/models/news_item.dart';
 import 'package:pet_matcher/widgets/admin_drawer.dart';
@@ -69,8 +70,11 @@ class _NewsScreenState extends State<NewsScreen> {
   Widget _buildNewsItem(
       BuildContext context, DocumentSnapshot document, String userType) {
     DateTime date = convertTimestampToDateTime(document['date']);
+    String documentID = document.id;
+    //print('The document ID is: $documentID');
 
     NewsItem post = NewsItem.fromMap({
+      'docID': documentID,
       'date': date,
       'imageUrl': document['imageUrl'],
       'title': document['title'],
@@ -135,8 +139,8 @@ class _NewsScreenState extends State<NewsScreen> {
         children: [
           favoriteIcon(),
           shareIcon(post),
-          editIcon(),
-        ], 
+          editIcon(post),
+        ],
       );
     } else {
       return Row(
@@ -170,11 +174,12 @@ class _NewsScreenState extends State<NewsScreen> {
     );
   }
 
-  Widget editIcon() {
-    return  IconButton(
+  Widget editIcon(NewsItem post) {
+    return IconButton(
       icon: Icon(Icons.edit_outlined),
       onPressed: () {
-        //NOTE: Still need to allow for editing article
+        Navigator.of(context)
+            .pushNamed(AddNewsItemScreen.routeName, arguments: post);
       },
     );
   }

--- a/lib/widgets/standard_input_box.dart
+++ b/lib/widgets/standard_input_box.dart
@@ -59,6 +59,7 @@ Widget standardInputBoxWithoutFlex({
   TextInputType keyboardType,
   int maxLines,
   bool alignLabelWithHint = false,
+  String initialValue,
 }) {
   return Padding(
       padding: addPadding,
@@ -71,6 +72,7 @@ Widget standardInputBoxWithoutFlex({
           padding: EdgeInsets.only(left: 15, right: 15, top: 5),
           child: TextFormField(
             controller: controller,
+            initialValue: initialValue,
             decoration: InputDecoration(
               alignLabelWithHint: alignLabelWithHint,
               border: InputBorder.none,


### PR DESCRIPTION
Summary of changes:
-updated news_item model class to include a docID to hold the Firebase Document ID assigned to a new newsPost
-updated news_screen.dart to retrieve the document ID from Firebase so I could use it to edit an existing newsPost and pass the data from an existing newsPost as an argument to the add_news_item_screen
-updated add_news_item_screen.dart to include logic for editing a newsPost and prefilling the text boxes with existing data
-updated the standardInputBox to take an optional initial value