### PR TITLE
Modify disposition 2

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,9 +1,9 @@
 import 'package:pet_matcher/navigation/routes.dart';
 import 'package:pet_matcher/navigation/startup_screen_controller.dart';
 import 'package:flutter/material.dart';
-import 'package:pet_matcher/screens/admin_home_screen.dart';
-import 'package:pet_matcher/screens/user_home_screen.dart';
-//import 'package:pet_matcher/screens/add_news_item_screen.dart';
+// import 'package:pet_matcher/screens/admin_home_screen.dart';
+// import 'package:pet_matcher/screens/user_home_screen.dart';
+// import 'package:pet_matcher/screens/add_news_item_screen.dart';
 import 'package:pet_matcher/models/animal.dart';
 import 'package:pet_matcher/services/animal_service.dart';
 import 'package:provider/provider.dart';
@@ -22,8 +22,6 @@ class PetMatcherApp extends StatelessWidget {
           create: (context) => locator<AnimalService>().animalStream(),
           initialData: [Animal.nullAnimal()],
         ),
-        // ChangeNotifierProvider<AnimalFilter>(
-        //     create: (context) => locator<AnimalFilter>())
       ],
       child: MaterialApp(
         title: 'Pet Matcher',

--- a/lib/models/animal.dart
+++ b/lib/models/animal.dart
@@ -4,8 +4,7 @@ class Animal {
   String type;
   String status;
   String breed;
-  List<dynamic> disposition;
-  //List<String> disposition;
+  List<dynamic> disposition = [];
   String age;
   String gender;
   String imageURL;

--- a/lib/models/animal.dart
+++ b/lib/models/animal.dart
@@ -4,7 +4,7 @@ class Animal {
   String type;
   String status;
   String breed;
-  String disposition;
+  List<dynamic> disposition;
   //List<String> disposition;
   String age;
   String gender;
@@ -49,7 +49,7 @@ class Animal {
         type = 'nullType',
         status = '',
         breed = '',
-        disposition = '',
+        disposition = [''],
         age = '',
         gender = '',
         imageURL = '';

--- a/lib/models/animal_filter.dart
+++ b/lib/models/animal_filter.dart
@@ -1,14 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:pet_matcher/models/animal.dart';
+import 'package:pet_matcher/services/animal_search_terms_dto.dart';
 
 class AnimalFilter extends ChangeNotifier {
   AnimalFilter();
 
-  Map<String, dynamic> _searchCriteria = Map.fromIterable(
-    Animal.allFields,
-    key: (field) => field,
-    value: (field) => null,
-  );
+  final _searchCriteria = AnimalSearchTermsDTO().toJson();
 
   String _sortCriteria = 'dateAdded';
 
@@ -23,6 +19,8 @@ class AnimalFilter extends ChangeNotifier {
     notifyListeners();
   }
 
+  // The call to re-sort takes place in selected item callback
+  // So really only using notifyListeners here, but may change later
   void updateSortCriteria(String newCriteria) {
     _sortCriteria = newCriteria;
     notifyListeners();

--- a/lib/screens/add_pet_screen.dart
+++ b/lib/screens/add_pet_screen.dart
@@ -19,6 +19,8 @@ class AddPetScreen extends StatefulWidget {
 class _AddPetScreenState extends State<AddPetScreen> {
   final formKey = GlobalKey<FormState>();
   final newAnimalData = AnimalDTO();
+  final Map<String, bool> dispositionValues =
+      Map.fromIterable(disposition, key: (e) => e, value: (e) => false);
   String imageUrl;
 
   @override
@@ -59,7 +61,8 @@ class _AddPetScreenState extends State<AddPetScreen> {
               animalAgeField(context, age),
               animalGenderDropdownField(context, gender),
               animalStatusField(context, adoptionStatus),
-              animalDispositionField(context, disposition),
+              dispositionField(),
+              // animalDispositionField(context, disposition),
               addAnimalButton(context),
             ]),
           ),
@@ -163,6 +166,37 @@ class _AddPetScreenState extends State<AddPetScreen> {
     );
   }
 
+  Widget dispositionField() {
+    return ListView(
+      shrinkWrap: true,
+      children: dispositionValues.keys.map(
+        (key) {
+          return CheckboxListTile(
+            title: Text(key),
+            value: dispositionValues[key],
+            onChanged: (value) {
+              setState(
+                () {
+                  dispositionValues[key] = value;
+                },
+              );
+            },
+          );
+        },
+      ).toList(),
+    );
+  }
+
+  void collectDispositions() {
+    dispositionValues.forEach(
+      (key, value) {
+        if (value) {
+          newAnimalData.disposition.add(key.toString());
+        }
+      },
+    );
+  }
+
   Widget addAnimalButton(BuildContext context) {
     return addPadding(elevatedButtonStandard('Add animal', createAnimal));
   }
@@ -172,6 +206,7 @@ class _AddPetScreenState extends State<AddPetScreen> {
       try {
         //save form
         formKey.currentState.save();
+        collectDispositions();
         //add animal to database
         FirebaseFirestore.instance.collection('animals').add({
           'name': newAnimalData.name,

--- a/lib/screens/add_pet_screen.dart
+++ b/lib/screens/add_pet_screen.dart
@@ -53,18 +53,19 @@ class _AddPetScreenState extends State<AddPetScreen> {
         child: SingleChildScrollView(
           child: Form(
             key: formKey,
-            child:
-                Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-              getChosenAnimalImage(),
-              animalNameField(context),
-              chooseAnimalBreedField(context, receivedAnimalType),
-              animalAgeField(context, age),
-              animalGenderDropdownField(context, gender),
-              animalStatusField(context, adoptionStatus),
-              dispositionField(),
-              // animalDispositionField(context, disposition),
-              addAnimalButton(context),
-            ]),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                getChosenAnimalImage(),
+                animalNameField(context),
+                chooseAnimalBreedField(context, receivedAnimalType),
+                animalAgeField(context, age),
+                animalGenderDropdownField(context, gender),
+                animalStatusField(context, adoptionStatus),
+                animalDispositionField(),
+                addAnimalButton(context),
+              ],
+            ),
           ),
         ),
       ),
@@ -153,20 +154,20 @@ class _AddPetScreenState extends State<AddPetScreen> {
     );
   }
 
-  //NOTE: need to change to a dropdown with checkboxes
-  Widget animalDispositionField(context, categories) {
-    return standardDropdownBox(
-      labelText: 'Disposition',
-      validatorPrompt: 'Select all that apply.',
-      validatorCondition: (value) => value.isEmpty,
-      onSaved: (value) {
-        newAnimalData.disposition = value;
-      },
-      items: categories,
-    );
-  }
+  //NOTE: This is the single-option dropdown version originally used
+  // Widget animalDispositionField(context, categories) {
+  //   return standardDropdownBox(
+  //     labelText: 'Disposition',
+  //     validatorPrompt: 'Select all that apply.',
+  //     validatorCondition: (value) => value.isEmpty,
+  //     onSaved: (value) {
+  //       newAnimalData.disposition = value;
+  //     },
+  //     items: categories,
+  //   );
+  // }
 
-  Widget dispositionField() {
+  Widget animalDispositionField() {
     return ListView(
       shrinkWrap: true,
       children: dispositionValues.keys.map(

--- a/lib/screens/animal_detail_screen.dart
+++ b/lib/screens/animal_detail_screen.dart
@@ -55,7 +55,6 @@ class _AnimalDetailScreenState extends State<AnimalDetailScreen> {
     }
   }
 
-
   Widget displayImage(Animal animal) {
     return Container(
       margin: EdgeInsets.symmetric(vertical: 10.0),
@@ -99,18 +98,22 @@ class _AnimalDetailScreenState extends State<AnimalDetailScreen> {
 
   Widget temperamentRow(Animal animal) {
     return Container(
-      child: ListTile(
-        leading: setIcon(animal),
-        title: Align(
-          alignment: Alignment(-1.5, 0),
-          child: Text('${animal.disposition}',
-              style: TextStyle(
-                fontSize: 14,
-                color: Colors.black,
-              )),
-        ),
-      ),
-    );
+        child: ListView.builder(
+            shrinkWrap: true,
+            itemCount: animal.disposition.length,
+            itemBuilder: (context, index) {
+              return ListTile(
+                leading: setIcon(animal.disposition[index]),
+                title: Align(
+                  alignment: Alignment(-1.5, 0),
+                  child: Text('${animal.disposition[index]}',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.black,
+                      )),
+                ),
+              );
+            }));
   }
 
   Widget datingBlerb(Animal animal) {
@@ -129,16 +132,23 @@ class _AnimalDetailScreenState extends State<AnimalDetailScreen> {
     );
   }
 
-  Widget setIcon(Animal animal) {
-    if (animal.disposition == 'Good with children') {
+  Widget setIcon(String disposition) {
+    List<String> happyDispositions = [
+      'Good with children',
+      'Good with other animals',
+    ];
+
+    List<String> warningDispositions = [
+      'Animal must be leashed at all times',
+    ];
+
+    if (happyDispositions.contains(disposition)) {
       return Icon(Icons.sentiment_very_satisfied,
           color: Colors.green, size: 18);
-    } else if (animal.disposition == 'Good with other animals') {
-      return Icon(Icons.sentiment_very_satisfied,
-          color: Colors.green, size: 18);
-    } else {
+    } else if (warningDispositions.contains(disposition)) {
       return Icon(Icons.warning, color: Colors.yellow, size: 18);
-    }
+    } else
+      return Icon(Icons.sentiment_neutral, color: Colors.white, size: 18);
   }
 
   Widget detailsBox(Animal animal) {

--- a/lib/services/animal_search_terms_dto.dart
+++ b/lib/services/animal_search_terms_dto.dart
@@ -1,0 +1,26 @@
+class AnimalSearchTermsDTO {
+  String type;
+  String breed;
+  String gender;
+  List<String> disposition;
+
+  AnimalSearchTermsDTO({
+    this.type,
+    this.breed,
+    this.gender,
+    this.disposition,
+  });
+
+  AnimalSearchTermsDTO.initial()
+      : type = null,
+        breed = null,
+        gender = null,
+        disposition = [];
+
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'breed:': breed,
+        'gender': gender,
+        'disposition': disposition,
+      };
+}

--- a/lib/services/animal_service.dart
+++ b/lib/services/animal_service.dart
@@ -24,13 +24,6 @@ class AnimalService {
     await _schema.doc('animals').set(_attributeJson);
   }
 
-  Future<List<Animal>> getAllAnimals() async {
-    QuerySnapshot _allAnimalData = await _animalCollection.get();
-    List<QueryDocumentSnapshot> dataList = _allAnimalData.docs;
-
-    return dataList.map((entry) => Animal.fromJSON(entry.data())).toList();
-  }
-
   Stream<List<Animal>> animalStream() {
     return _animalCollection.snapshots().map((snapshot) {
       if (snapshot.docs.length != 0) {
@@ -46,6 +39,13 @@ class AnimalService {
         return [null];
       }
     });
+  }
+
+  Stream<List<Animal>> availableAnimalStream() {
+    return _availableAnimalCollection.snapshots().map((snapshot) => snapshot
+        .docs
+        .map((animalEntry) => Animal.fromJSON(animalEntry.data()))
+        .toList());
   }
 
   List<Animal> filterAnimalList(
@@ -70,18 +70,14 @@ class AnimalService {
         .toList();
   }
 
-  Stream<List<Animal>> availableAnimalStream() {
-    return _availableAnimalCollection.snapshots().map((snapshot) => snapshot
-        .docs
-        .map((animalEntry) => Animal.fromJSON(animalEntry.data()))
-        .toList());
-  }
-
   bool meetsCriteria(dynamic animalValue, dynamic searchValue) {
-    if (animalValue.runtimeType == String) {
+    if (animalValue is String) {
       return animalValue == searchValue;
     }
-    if (animalValue.runtimeType == List) {
+    if (animalValue is List) {
+      if (searchValue.length == 0) {
+        return true;
+      }
       return (animalValue.any((item) => searchValue.contains(item)));
     }
     return animalValue == searchValue;

--- a/lib/services/new_animal_dto.dart
+++ b/lib/services/new_animal_dto.dart
@@ -4,8 +4,7 @@ class AnimalDTO {
   String type;
   String status;
   String breed;
-  //List<String> disposition;
-  String disposition;
+  List<String> disposition = [];
   String age;
   String gender;
   String imageURL;

--- a/lib/utility_functions.dart
+++ b/lib/utility_functions.dart
@@ -1,0 +1,5 @@
+// Borrow this function https://pub.dev/packages/dson_core
+// Tried importing dson_core in pubspec.yaml, but had dependency version
+// conflic with mockito
+bool isPrimitive(value) =>
+    value is String || value is num || value is bool || value == null;

--- a/lib/widgets/animal_search_form.dart
+++ b/lib/widgets/animal_search_form.dart
@@ -16,9 +16,6 @@ class _AnimalSearchFormState extends State<AnimalSearchForm> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final breedFieldKey = GlobalKey<FormFieldState>();
 
-  String selectedType;
-  String selectedBreed;
-  String selectedGender;
   Map<String, bool> dispositionValues =
       Map.fromIterable(disposition, key: (e) => e, value: (e) => false);
 
@@ -26,22 +23,11 @@ class _AnimalSearchFormState extends State<AnimalSearchForm> {
     'type': null,
     'breed': null,
     'gender': null,
-    // 'disposition':
-    // Map.fromIterable(disposition, key: (e) => e, value: (e) => false),
+    'disposition': [],
   };
-
-  // List<String> selectedDispositions = [];
 
   String breedFieldLabel = 'Choose animal type to view breeds';
   Function breedOnChanged;
-
-  // void getSelectedDispositions() {
-  //   dispositionValues.forEach((key, value) {
-  //     if (value) {
-  //       selectedDispositions.add(key);
-  //     }
-  //   });
-  // }
 
   @override
   Widget build(BuildContext context) {
@@ -71,24 +57,9 @@ class _AnimalSearchFormState extends State<AnimalSearchForm> {
           child: Text('Submit'),
           onPressed: () {
             if (_formKey.currentState.validate()) {
+              collectDispositions();
               Provider.of<AnimalFilter>(context, listen: false)
                   .update(searchTerms);
-
-              // if (searchTerms['breed'] != null) {
-              //   Provider.of<AnimalFilter>(context, listen: false).update({
-              //     'breed': (animal) =>
-              //         animal.type == searchTerms['breed'] ? true : false
-              //   });
-              // }
-
-              // if (searchTerms['gender'] != null) {
-              //   Provider.of<AnimalFilter>(context, listen: false).update(
-              //     {
-              //       'gender': (animal) =>
-              //           animal.type == searchTerms['gender'] ? true : false
-              //     },
-              //   );
-              // }
               Navigator.of(context).pop();
             }
           },
@@ -108,13 +79,23 @@ class _AnimalSearchFormState extends State<AnimalSearchForm> {
             onChanged: (value) {
               setState(
                 () {
-                  // dispositionValues[key] = value;
+                  dispositionValues[key] = value;
                 },
               );
             },
           );
         },
       ).toList(),
+    );
+  }
+
+  void collectDispositions() {
+    dispositionValues.forEach(
+      (key, value) {
+        if (value) {
+          searchTerms[disposition].add(key);
+        }
+      },
     );
   }
 

--- a/lib/widgets/animal_search_form.dart
+++ b/lib/widgets/animal_search_form.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:pet_matcher/services/animal_search_terms_dto.dart';
 import 'package:provider/provider.dart';
-import 'package:pet_matcher/locator.dart';
 import 'package:pet_matcher/models/animal_category_constants.dart';
 import 'package:pet_matcher/models/animal_filter.dart';
 import 'package:pet_matcher/widgets/filter_dropdown_box.dart';
@@ -14,20 +14,18 @@ class AnimalSearchForm extends StatefulWidget {
 
 class _AnimalSearchFormState extends State<AnimalSearchForm> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+  final searchTerms = AnimalSearchTermsDTO.initial();
+
+  // part of logic that makes breed selectable onlyh if type selected
   final breedFieldKey = GlobalKey<FormFieldState>();
-
-  Map<String, bool> dispositionValues =
-      Map.fromIterable(disposition, key: (e) => e, value: (e) => false);
-
-  Map<String, dynamic> searchTerms = {
-    'type': null,
-    'breed': null,
-    'gender': null,
-    'disposition': [],
-  };
-
   String breedFieldLabel = 'Choose animal type to view breeds';
   Function breedOnChanged;
+
+  // Use a map of disposition values when form is active
+  // Will collect any keys w/ val == true into List<String> upon Submit
+  Map<String, bool> dispositionValues =
+      Map.fromIterable(disposition, key: (e) => e, value: (e) => false);
 
   @override
   Widget build(BuildContext context) {
@@ -53,18 +51,73 @@ class _AnimalSearchFormState extends State<AnimalSearchForm> {
       ),
       title: Text('Search for Animals'),
       actions: <Widget>[
-        ElevatedButton(
-          child: Text('Submit'),
-          onPressed: () {
-            if (_formKey.currentState.validate()) {
-              collectDispositions();
-              Provider.of<AnimalFilter>(context, listen: false)
-                  .update(searchTerms);
-              Navigator.of(context).pop();
-            }
-          },
-        ),
+        searchButton(context),
       ],
+    );
+  }
+
+  Widget searchButton(BuildContext context) {
+    return ElevatedButton(
+      child: Text('Submit'),
+      onPressed: () {
+        if (_formKey.currentState.validate()) {
+          collectDispositions();
+          Provider.of<AnimalFilter>(context, listen: false)
+              .update(searchTerms.toJson());
+          Navigator.of(context).pop();
+        }
+      },
+    );
+  }
+
+  Widget typeField() {
+    return filterDropDownBox(
+      labelText: 'Animal type',
+      items: animalType,
+      value: searchTerms.type,
+      onChanged: (value) {
+        searchTerms.type = value;
+        breedFieldKey.currentState.reset();
+        breedOnChanged = (value) {
+          searchTerms.breed = value;
+        };
+        breedFieldLabel = 'Breed';
+        setState(() {});
+      },
+    );
+  }
+
+  Widget breedField() {
+    return filterDropDownBox(
+      key: breedFieldKey,
+      labelText: breedFieldLabel,
+      items: breedOptions(),
+      value: searchTerms.breed,
+      onChanged: breedOnChanged,
+    );
+  }
+
+  List<String> breedOptions() {
+    if (searchTerms.type == 'Dog') {
+      return dogBreeds;
+    }
+    if (searchTerms.type == 'Cat') {
+      return catBreeds;
+    }
+    if (searchTerms.type == 'Other') {
+      return otherAnimalTypes;
+    }
+    return [''];
+  }
+
+  Widget genderField() {
+    return filterDropDownBox(
+      labelText: 'Gender',
+      items: gender,
+      value: searchTerms.gender,
+      onChanged: (value) {
+        searchTerms.gender = value;
+      },
     );
   }
 
@@ -93,59 +146,8 @@ class _AnimalSearchFormState extends State<AnimalSearchForm> {
     dispositionValues.forEach(
       (key, value) {
         if (value) {
-          searchTerms[disposition].add(key);
+          searchTerms.disposition.add(key);
         }
-      },
-    );
-  }
-
-  Widget typeField() {
-    return filterDropDownBox(
-      labelText: 'Animal type',
-      items: animalType,
-      value: searchTerms['type'],
-      onChanged: (value) {
-        searchTerms['type'] = value;
-        breedFieldKey.currentState.reset();
-        breedOnChanged = (value) {
-          searchTerms['breed'] = value;
-        };
-        breedFieldLabel = 'Breed';
-        setState(() {});
-      },
-    );
-  }
-
-  Widget breedField() {
-    return filterDropDownBox(
-      key: breedFieldKey,
-      labelText: breedFieldLabel,
-      items: breedOptions(),
-      value: searchTerms['breed'],
-      onChanged: breedOnChanged,
-    );
-  }
-
-  List<String> breedOptions() {
-    if (searchTerms['type'] == 'Dog') {
-      return dogBreeds;
-    }
-    if (searchTerms['type'] == 'Cat') {
-      return catBreeds;
-    }
-    if (searchTerms['type'] == 'Other') {
-      return otherAnimalTypes;
-    }
-    return [''];
-  }
-
-  Widget genderField() {
-    return filterDropDownBox(
-      labelText: 'Gender',
-      items: gender,
-      value: searchTerms['gender'],
-      onChanged: (value) {
-        searchTerms['gender'] = value;
       },
     );
   }


### PR DESCRIPTION
Made changes to allow app to handle disposition as a list of strings instead of a single string.

--Change disposition in Animal model from String to LIst<dynamic>. Tried List<String> but had problems handling stream.
--In New Animal DTO, changed to List<String>
--Created AnimalSearchDTO to transfer data from form to AnimalFIlter ChangeNotifier widget. Decided against using a plain Animal Model or NewAnimal DTO. If we want to add new search parameters, may require update to AnimalService meetsCriteria() function. Having a DTO specifically for query params might help us remember that if they change, AnimalService needs to change.
--In Animal Service, Modified meetsCriteria() function in AnimalServices to handle Strings and Lists. Also rearranged functions to group related things together. Removed an unused query function. 
--Animal Filter (the Change Notifier): Change object that holds query params to AnimalSearchTermsDTO.
--Add Pet Screen:  Update to handle list of dispositions
--Animal Detail Screen: Update temperamentRow to handle multiple dispositons
--App.dart: import & comment cleanup
--Added a utiliity functions file, though ended up not using the one function in it.





