### PR TITLE
Add 'Terrier' to dogBreeds in animal_category_constants

### DIFF
--- a/lib/models/animal_category_constants.dart
+++ b/lib/models/animal_category_constants.dart
@@ -40,7 +40,7 @@ List<String> dogBreeds = [
   'English Springer Spaniel',
   'Foxhound',
   'French Bulldog'
-  'German Shepherd Dog',
+      'German Shepherd Dog',
   'German Shorthaired Pointer',
   'Golden Retriever',
   'Great Dane',
@@ -67,6 +67,7 @@ List<String> dogBreeds = [
   'Siberian Husky',
   'Shiba Inu',
   'Schnauzer',
+  'Terrier',
   'Vizsla',
   'Weimaraner',
   'Whippet',
@@ -74,7 +75,7 @@ List<String> dogBreeds = [
 
 List<String> catBreeds = [
   'Abyssinian'
-  'American Shorthair',
+      'American Shorthair',
   'Bengal',
   'British Shorthair',
   'Burmese',


### PR DESCRIPTION
'Terrier' somehow got deleted from the list of dog breeds, so we were getting an error when trying to edit an exiting Terrier. Put Terrier back on the list.