### PR TITLE
delete news item

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,12 +1,6 @@
 import 'package:pet_matcher/navigation/routes.dart';
 import 'package:pet_matcher/navigation/startup_screen_controller.dart';
 import 'package:flutter/material.dart';
-// import 'package:pet_matcher/screens/admin_home_screen.dart';
-// import 'package:pet_matcher/screens/user_home_screen.dart';
-// import 'package:pet_matcher/screens/add_news_item_screen.dart';
-import 'package:pet_matcher/models/animal.dart';
-import 'package:pet_matcher/screens/admin_home_screen.dart';
-import 'package:pet_matcher/screens/animal_inventory_screen.dart';
 import 'package:pet_matcher/services/animal_service.dart';
 import 'package:provider/provider.dart';
 import 'package:pet_matcher/services/app_user_service.dart';
@@ -22,7 +16,6 @@ class PetMatcherApp extends StatelessWidget {
         ),
         StreamProvider(
           create: (context) => locator<AnimalService>().animalStream(),
-          // initialData: [Animal.nullAnimal()],
         ),
       ],
       child: MaterialApp(
@@ -30,10 +23,8 @@ class PetMatcherApp extends StatelessWidget {
         theme: ThemeData(
           primarySwatch: Colors.blue,
         ),
-        // home: startupScreenSelector(context),
         routes: RouteNames.routes,
         initialRoute: StartUpScreenController.routeName,
-        //initialRoute: AdminHomeScreen.routeName,
       ),
     );
   }

--- a/lib/screens/animal_inventory_screen.dart
+++ b/lib/screens/animal_inventory_screen.dart
@@ -1,5 +1,4 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:pet_matcher/models/animal.dart';
@@ -11,6 +10,7 @@ import 'package:pet_matcher/screens/choose_animal_type_screen.dart';
 import 'package:pet_matcher/widgets/admin_drawer.dart';
 import 'package:pet_matcher/widgets/animal_search_button.dart';
 import 'package:pet_matcher/widgets/animal_sort_button.dart';
+import 'package:pet_matcher/widgets/delete_dialog.dart';
 import 'package:pet_matcher/widgets/user_drawer.dart';
 import 'package:provider/provider.dart';
 
@@ -229,49 +229,11 @@ Widget editIcon(Animal animal, BuildContext context) {
 
 Widget deleteIcon(Animal animal, BuildContext context) {
   return IconButton(
-      icon: Icon(Icons.delete),
-      tooltip: 'Remove animal',
-      onPressed: () {
-        _showMyDialog(animal, context);
-      });
-}
-
-//Reference: https://api.flutter.dev/flutter/material/AlertDialog-class.html
-Future<void> _showMyDialog(Animal animal, BuildContext context) async {
-  return showDialog<void>(
-    context: context,
-    barrierDismissible: true,
-    builder: (BuildContext context) {
-      return AlertDialog(
-        title: Text('Delete this animal?'),
-        content: SingleChildScrollView(
-          child: ListBody(
-            children: [
-              Text(
-                  'Would you like to permanently remove this animal from the animal inventory?'),
-            ],
-          ),
-        ),
-        actions: [
-          TextButton(
-            child: Text('No'),
-            onPressed: () {
-              Navigator.of(context).pop();
-            },
-          ),
-          TextButton(
-            child: Text('Yes'),
-            onPressed: () {
-              FirebaseFirestore.instance
-                  .collection('animals')
-                  .doc(animal.animalID)
-                  .delete();
-              Navigator.of(context).pop();
-            },
-          ),
-        ],
-      );
-    },
+    icon: Icon(Icons.delete),
+    tooltip: 'Remove animal',
+    onPressed: () {
+      showMyDialog('animals', animal, context);
+    }
   );
 }
 

--- a/lib/screens/news_screen.dart
+++ b/lib/screens/news_screen.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:pet_matcher/widgets/delete_dialog.dart';
 import 'package:provider/provider.dart';
 import 'package:pet_matcher/screens/add_news_item_screen.dart';
 import 'package:share/share.dart';
@@ -139,9 +140,9 @@ class _NewsScreenState extends State<NewsScreen> {
     if (userType == 'admin') {
       return Row(
         children: [
-          favoriteIcon(),
           shareIcon(post),
           editIcon(post),
+          deleteIcon(post, context),
         ],
       );
     } else {
@@ -153,6 +154,15 @@ class _NewsScreenState extends State<NewsScreen> {
       );
     }
   }
+
+  Widget deleteIcon(NewsItem post, BuildContext context) {
+  return IconButton(
+      icon: Icon(Icons.delete),
+      tooltip: 'Remove post',
+      onPressed: () {
+        showMyDialog('newsPost', post, context);
+      });
+}
 
   Widget favoriteIcon() {
     return IconButton(

--- a/lib/widgets/delete_dialog.dart
+++ b/lib/widgets/delete_dialog.dart
@@ -1,0 +1,62 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+//Reference: https://api.flutter.dev/flutter/material/AlertDialog-class.html
+Future<void> showMyDialog(
+    String collectionName, var collectionObject, BuildContext context) async {
+  String titleText;
+  String bodyText;
+  String id;
+
+  //check if item is an animal
+  if (collectionName == 'animals') {
+    titleText = 'Delete this animal?';
+    bodyText =
+        'Would you like to permanently remove this animal from the animal inventory?';
+    id = '${collectionObject.animalID}';
+  }
+  //check if item is a newsPost
+  else if (collectionName == 'newsPost') {
+    titleText = 'Delete this news post?';
+    bodyText =
+        'Would you like to permanently remove this post from the news feed?';
+    id = '${collectionObject.docID}';
+  } else {
+    print('Error. This collection does not exist.');
+  }
+
+  return showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        title: Text(titleText),
+        content: SingleChildScrollView(
+          child: ListBody(
+            children: [
+              Text(bodyText),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            child: Text('No'),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+          TextButton(
+            child: Text('Yes'),
+            onPressed: () {
+              FirebaseFirestore.instance
+                  .collection('$collectionName')
+                  .doc(id)
+                  .delete();
+              Navigator.of(context).pop();
+            },
+          ),
+        ],
+      );
+    },
+  );
+}


### PR DESCRIPTION
Summary of changes
-added functionality to delete a news post
-refactored and created a delete_dialog.dart file which contains a widget that handles the alert dialog and deletion of an item from the database (can be used for animals and newsItems) and used it in both the animal_inventory_screen and news_screen 
-removed extra imports in app.dart to get rid of warnings