### PR TITLE
Add favoriting to UserInv. Move userCreate code to AppUserServices

### DIFF
--- a/lib/models/app_user.dart
+++ b/lib/models/app_user.dart
@@ -7,8 +7,8 @@ class AppUser {
   String city;
   String state;
   int zipCode;
-  String role;
-  List favorites;
+  String role = 'publicUser';
+  List<dynamic> favorites = [];
 
   AppUser({
     this.email,
@@ -30,7 +30,6 @@ class AppUser {
         zipCode = 0,
         role = '',
         favorites = [];
-
 
   AppUser.fromJSON(Map<String, dynamic> json) {
     email = json['email'];

--- a/lib/models/user_favorites.dart
+++ b/lib/models/user_favorites.dart
@@ -1,0 +1,11 @@
+class UserFavorites {
+  List<dynamic> favorites = [];
+
+  UserFavorites({this.favorites});
+
+  UserFavorites.initial() : favorites = [];
+
+  UserFavorites.fromJSON(Map<String, dynamic> json) {
+    favorites = json['favorites'];
+  }
+}

--- a/lib/screens/account_setup_screen.dart
+++ b/lib/screens/account_setup_screen.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart' as fb_auth;
 import 'package:flutter/material.dart';
+import 'package:pet_matcher/locator.dart';
 import 'package:pet_matcher/screens/login_screen.dart';
 import 'package:pet_matcher/services/app_user_service.dart';
 import 'package:pet_matcher/services/new_app_user_dto.dart';
@@ -173,8 +174,7 @@ class _AccountSetupScreenState extends State<AccountSetupScreen> {
             },
           ),
         ),
-        Text('I am a shelter admin',
-            style: Styles.subtitleTextWhite),
+        Text('I am a shelter admin', style: Styles.subtitleTextWhite),
       ],
     );
   }
@@ -189,14 +189,10 @@ class _AccountSetupScreenState extends State<AccountSetupScreen> {
     if (formKey.currentState.validate()) {
       try {
         formKey.currentState.save();
-        fb_auth.UserCredential newUserCredential =
-            await firebaseAuth.createUserWithEmailAndPassword(
-                email: _emailController.text,
-                password: _passwordController.text);
-        fb_auth.User newFirebaseUser = newUserCredential.user;
-        newAppUserData.email = newFirebaseUser.email;
-        final appUserService = AppUserService(firebaseAuth: firebaseAuth);
-        await appUserService.uploadNewUser(newAppUserData, newFirebaseUser.uid);
+        await locator<AppUserService>().createNewUser(
+            email: _emailController.text,
+            password: _passwordController.text,
+            newAppUserData: newAppUserData);
         Navigator.of(context).pushReplacementNamed(LoginScreen.routeName);
       } catch (e) {
         print(e);

--- a/lib/services/app_user_service.dart
+++ b/lib/services/app_user_service.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:pet_matcher/models/animal.dart';
 import 'package:pet_matcher/models/app_user.dart';
+import 'package:pet_matcher/models/user_favorites.dart';
 import 'package:pet_matcher/services/new_app_user_dto.dart';
 
 class AppUserService {
@@ -17,12 +18,13 @@ class AppUserService {
     await _users.doc(uid).set(newAppUserData.toJson());
   }
 
-  Future<AppUser> getAppUser(String uid) async {
-    if (uid == null) {
-      return AppUser.initial();
-    }
-    DocumentSnapshot _userData = await _users.doc(uid).get();
-    return AppUser.fromJSON(_userData.data());
+  Future<void> createNewUser(
+      {String email, String password, NewAppUserDTO newAppUserData}) async {
+    UserCredential newUserCredential = await firebaseAuth
+        .createUserWithEmailAndPassword(email: email, password: password);
+    User newFirebaseUser = newUserCredential.user;
+    newAppUserData.email = newFirebaseUser.email;
+    await uploadNewUser(newAppUserData, newFirebaseUser.uid);
   }
 
   Future<AppUser> appUserSnapshot() async {
@@ -32,6 +34,13 @@ class AppUserService {
     DocumentSnapshot _appUser =
         await _users.doc(firebaseAuth.currentUser.uid).get();
     return AppUser.fromJSON(_appUser.data());
+  }
+
+  Future<String> get userRole async {
+    AppUser appUser = await appUserSnapshot();
+    String userRole = appUser?.role;
+    userRole ??= 'unknown';
+    return userRole;
   }
 
   Stream<AppUser> get appUserAuthStateChange {
@@ -44,11 +53,46 @@ class AppUserService {
     });
   }
 
-  Future<String> get userRole async {
-    AppUser appUser = await appUserSnapshot();
-    String userRole = appUser?.role;
-    userRole ??= 'unknown';
-    return userRole;
+  Stream<UserFavorites> favoritesOnDataChange() {
+    return _users.doc(firebaseAuth.currentUser.uid).snapshots().map((userDoc) {
+      if (userDoc == null) {
+        return UserFavorites.initial();
+      }
+      return UserFavorites.fromJSON(userDoc.data());
+    });
+  }
+
+  void addToFavorites(Animal animal) {
+    _users.doc(firebaseAuth.currentUser.uid).update({
+      'favorites': FieldValue.arrayUnion([animal.animalID])
+    });
+  }
+
+  void removeFromFavorites(Animal animal) {
+    _users.doc(firebaseAuth.currentUser.uid).update({
+      'favorites': FieldValue.arrayRemove([animal.animalID])
+    });
+  }
+
+  void updateFavorites(Animal animal, UserFavorites userFavorites) {
+    if (userFavorites.favorites.contains(animal.animalID)) {
+      removeFromFavorites(animal);
+    } else {
+      addToFavorites(animal);
+    }
+  }
+
+  Stream<AppUser> get appUserDataChange {
+    return userDataStream.map((e) {
+      if (e == null) {
+        return AppUser.initial();
+      }
+      return AppUser.fromJSON(e.data());
+    });
+  }
+
+  Stream<DocumentSnapshot> get userDataStream {
+    return _users.doc(firebaseAuth.currentUser?.uid).snapshots();
   }
 
   Future<void> signIn({String email, String password}) async {
@@ -58,15 +102,16 @@ class AppUserService {
     );
   }
 
-  Stream<DocumentSnapshot> get userDataStream {
-    return _users.doc(firebaseAuth.currentUser.uid).snapshots();
-  }
-
   // Stream<AppUser> get currentAppUser async* {
   //   AppUser appUser = await appUserSnapshot();
   //   yield appUser;
   // }
 
-  // Future<AppUser> appUserSnapshot
-
+  Future<AppUser> getAppUser(String uid) async {
+    if (uid == null) {
+      return AppUser.initial();
+    }
+    DocumentSnapshot _userData = await _users.doc(uid).get();
+    return AppUser.fromJSON(_userData.data());
+  }
 }

--- a/lib/services/new_app_user_dto.dart
+++ b/lib/services/new_app_user_dto.dart
@@ -6,6 +6,7 @@ class NewAppUserDTO {
   String state;
   int zipCode;
   String role = 'publicUser';
+  List<String> favorites = <String>[];
 
   Map<String, dynamic> toJson() => {
         'email': email,
@@ -15,5 +16,6 @@ class NewAppUserDTO {
         'state': state,
         'zipCode': zipCode,
         'role': role,
+        'favorites': favorites,
       };
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       name: cached_network_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.1"
+    version: "3.0.0"
   characters:
     dependency: transitive
     description:
@@ -292,14 +292,14 @@ packages:
       name: flutter_blurhash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0"
+    version: "0.6.0"
   flutter_cache_manager:
     dependency: transitive
     description:
       name: flutter_cache_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "3.0.2"
   flutter_form_builder:
     dependency: "direct main"
     description:
@@ -461,7 +461,7 @@ packages:
       name: octo_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "1.0.0+1"
   package_config:
     dependency: transitive
     description:
@@ -561,12 +561,12 @@ packages:
     source: hosted
     version: "2.0.0"
   rxdart:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.25.0"
+    version: "0.27.0"
   share:
     dependency: "direct main"
     description:
@@ -621,6 +621,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  stream_transform:
+    dependency: "direct main"
+    description:
+      name: stream_transform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -707,4 +714,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.24.0-10"
+  flutter: ">=1.24.0-10.2.pre"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   #camera/photos
   image_picker: ^0.7.4
-  cached_network_image: ^2.5.0
+  cached_network_image: ^3.0.0
   
   #GetIt
   get_it: ^6.1.0
@@ -56,6 +56,9 @@ dependencies:
   #forms
   flutter_form_builder: ^6.0.0
   multi_select_flutter: ^4.0.0
+
+  rxdart: ^0.27.0
+  stream_transform: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Add UserFavorites Model. This is only used when pulling existing favorites data (the favorites property of an AppUser is still a regular list for now).

Modified user creation code so that newly created users have an empty favorites list as one of their properties.

Add code to AppUserService to create a steam of UserFavorites, and use this to create a StreamProvider of UserFavorites at the top of the AnimalInventory screen. The color of the favorite on an animal's image depends on this Provider. The callback on each favorite icon uses a function in AppUserServices to add/remove an animal from user's favorites in the database. Any change to the favorites sends a new event to the Provider's stream, which causes the icon widget to be rebuilt (with appropriate color).

Moved details of userCreation from AddUserScreen to AppServices.