### PR TITLE
Provider logout exceptions, all images CachedNetwork, remove favicon …

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,7 +1,7 @@
 import 'package:pet_matcher/navigation/routes.dart';
 import 'package:pet_matcher/navigation/startup_screen_controller.dart';
 import 'package:flutter/material.dart';
-import 'package:pet_matcher/screens/favorite_screen.dart';
+import 'package:pet_matcher/models/animal.dart';
 import 'package:pet_matcher/services/animal_service.dart';
 import 'package:pet_matcher/styles.dart';
 import 'package:provider/provider.dart';

--- a/lib/screens/animal_inventory_screen.dart
+++ b/lib/screens/animal_inventory_screen.dart
@@ -35,6 +35,7 @@ class AnimalInventoryScreen extends StatelessWidget {
         StreamProvider<UserFavorites>(
           create: (_) => locator<AppUserService>().favoritesOnDataChange(),
           initialData: UserFavorites.initial(),
+          catchError: (_, __) => UserFavorites.initial(),
         ),
       ],
       child: Scaffold(

--- a/lib/screens/favorite_screen.dart
+++ b/lib/screens/favorite_screen.dart
@@ -24,6 +24,7 @@ class FavoriteScreen extends StatelessWidget {
     return StreamProvider<UserFavorites>(
       create: (_) => locator<AppUserService>().favoritesOnDataChange(),
       initialData: UserFavorites.initial(),
+      catchError: (_, __) => UserFavorites.initial(),
       child: Scaffold(
         appBar: AppBar(
           centerTitle: true,

--- a/lib/screens/news_screen.dart
+++ b/lib/screens/news_screen.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -96,7 +97,10 @@ class _NewsScreenState extends State<NewsScreen> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Container(child: Image.network('${post.imageUrl}')),
+            Container(
+                child: CachedNetworkImage(
+              imageUrl: post.imageUrl,
+            )),
             ListTile(
                 title: addPadding(
                   Text(
@@ -152,12 +156,12 @@ class _NewsScreenState extends State<NewsScreen> {
   }
 
   Widget deleteIcon(NewsItem post, BuildContext context) {
-  return IconButton(
-      icon: Icon(Icons.delete),
-      tooltip: 'Remove post',
-      onPressed: () {
-        showMyDialog('newsPost', post, context);
-      });
+    return IconButton(
+        icon: Icon(Icons.delete),
+        tooltip: 'Remove post',
+        onPressed: () {
+          showMyDialog('newsPost', post, context);
+        });
   }
 
   Widget shareIcon(NewsItem post) {

--- a/lib/services/app_user_service.dart
+++ b/lib/services/app_user_service.dart
@@ -54,7 +54,10 @@ class AppUserService {
   }
 
   Stream<UserFavorites> favoritesOnDataChange() {
-    return _users.doc(firebaseAuth.currentUser.uid).snapshots().map((userDoc) {
+    return _users
+        .doc(firebaseAuth?.currentUser?.uid)
+        ?.snapshots()
+        ?.map((userDoc) {
       if (userDoc == null) {
         return UserFavorites.initial();
       }

--- a/lib/widgets/admin_drawer.dart
+++ b/lib/widgets/admin_drawer.dart
@@ -112,8 +112,8 @@ class AdminDrawer extends StatelessWidget {
 */
 
   void logout(BuildContext context) async {
-    await locator<AppUserService>().firebaseAuth.signOut();
     Navigator.of(context).popUntil((route) => route.isFirst);
     Navigator.of(context).pushReplacementNamed(LandingScreen.routeName);
+    await locator<AppUserService>().firebaseAuth.signOut();
   }
 }

--- a/lib/widgets/user_drawer.dart
+++ b/lib/widgets/user_drawer.dart
@@ -103,8 +103,8 @@ class UserDrawer extends StatelessWidget {
   }
 
   void logout(BuildContext context) async {
-    await locator<AppUserService>().firebaseAuth.signOut();
     Navigator.of(context).popUntil((route) => route.isFirst);
     Navigator.of(context).pushReplacementNamed(LandingScreen.routeName);
+    await locator<AppUserService>().firebaseAuth.signOut();
   }
 }


### PR DESCRIPTION
-Fix Provider Exceptions that were occurring on logout from certain screens
-Make all network images "CachedNetworkImages" to reduce loading time
-Remove favorites icon from Admin's Animal Detail view, and move the edit icon for this view to corner of image (same place where favorites icon is located for User's Animal Detail View)
- Modify logout callbacks so that screens pop before firebaseUser is signed out.