### PR TITLE
Modify add animal and edit animal

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -3,6 +3,7 @@ import 'package:pet_matcher/navigation/startup_screen_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:pet_matcher/models/animal.dart';
 import 'package:pet_matcher/services/animal_service.dart';
+import 'package:pet_matcher/services/image_service.dart';
 import 'package:pet_matcher/styles.dart';
 import 'package:provider/provider.dart';
 import 'package:pet_matcher/services/app_user_service.dart';

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,7 +1,7 @@
 import 'package:pet_matcher/navigation/routes.dart';
 import 'package:pet_matcher/navigation/startup_screen_controller.dart';
 import 'package:flutter/material.dart';
-import 'package:pet_matcher/screens/favorite_screen.dart';
+import 'package:pet_matcher/models/animal.dart';
 import 'package:pet_matcher/services/animal_service.dart';
 import 'package:pet_matcher/styles.dart';
 import 'package:provider/provider.dart';

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -7,6 +7,7 @@ import 'package:pet_matcher/models/animal_filter.dart';
 import 'package:pet_matcher/navigation/startup_screen_controller.dart';
 import 'package:pet_matcher/services/animal_service.dart';
 import 'package:pet_matcher/services/app_user_service.dart';
+import 'package:pet_matcher/services/image_service.dart';
 
 GetIt locator = GetIt.instance;
 
@@ -20,8 +21,7 @@ void setupLocator() {
 
   locator.registerFactory(() => AnimalFilter());
 
-  // locator.registerFactoryParam<AnimalFilter, String, void>(
-  //     (screenName, _) => AnimalFilter(screenName: screenName));
-
   locator.registerSingleton(() => StartUpScreenController());
+
+  locator.registerLazySingleton(() => ImageService());
 }

--- a/lib/screens/add_pet_screen.dart
+++ b/lib/screens/add_pet_screen.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:pet_matcher/models/animal.dart';
@@ -21,39 +22,39 @@ class AddPetScreen extends StatefulWidget {
 class _AddPetScreenState extends State<AddPetScreen> {
   final formKey = GlobalKey<FormState>();
   Animal receivedAnimal = Animal();
+  bool _imageLoading = false;
 
   final Map<String, bool> dispositionValues =
       Map.fromIterable(disposition, key: (e) => e, value: (e) => false);
   String imageUrl;
 
-  @override
-  void initState() {
-    super.initState();
-    getImageUrl();
-  }
+  // @override
+  // void initState() {
+  //   super.initState();
+  //   getImageUrl();
+  // }
 
   void getImageUrl() async {
-    imageUrl = await retrieveImageUrl();
+    receivedAnimal.imageURL = await retrieveImageUrl();
+    _imageLoading = false;
     setState(() {});
   }
 
   Widget build(BuildContext context) {
-    if (imageUrl == null) {
-      return Center(child: CircularProgressIndicator());
-    }
+    // if (imageUrl == null) {
+    //   return Center(child: CircularProgressIndicator());
+    // }
 
     var receivedArgument = ModalRoute.of(context).settings.arguments;
     //if receivedArgument is String, the animal is a new animal
     if (receivedArgument is String) {
-      receivedAnimal.animalID = null;
-      receivedAnimal.imageURL = imageUrl;
       receivedAnimal.type = '$receivedArgument';
+      receivedAnimal.dateAdded = DateTime.now();
     }
     //if receivedArgument is an Animal object, the animal already exists in database
     else {
-      receivedAnimal = ModalRoute.of(context).settings.arguments;
+      receivedAnimal = receivedArgument;
     }
-    receivedAnimal.dateAdded = DateTime.now();
 
     return Scaffold(
       appBar: AppBar(
@@ -69,7 +70,7 @@ class _AddPetScreenState extends State<AddPetScreen> {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                getChosenAnimalImage(),
+                imageField(),
                 animalNameField(context),
                 chooseAnimalBreedField(context, receivedAnimal.type),
                 animalAgeField(context, age),
@@ -88,8 +89,76 @@ class _AddPetScreenState extends State<AddPetScreen> {
   Widget getChosenAnimalImage() {
     return Padding(
         padding: EdgeInsets.only(top: 20, bottom: 10),
-        child: Image.network('$imageUrl',
-            height: 250, width: 200, fit: BoxFit.fitWidth));
+        child: SizedBox(
+          height: 250,
+          width: 200,
+          child: Icon(Icons.image_search),
+        ));
+  }
+
+  Widget imageField() {
+    return Padding(
+      padding: EdgeInsets.only(top: 20, bottom: 10),
+      child: GestureDetector(
+        onTap: getImageUrl,
+        child: imageDisplaySelector(),
+      ),
+    );
+  }
+
+  // Widget displayedImage() {
+  //   return Padding(
+  //       padding: EdgeInsets.only(top: 20, bottom: 10),
+  //       child: SizedBox(
+  //         height: 250,
+  //         width: 200,
+  //         child: imageDisplaySelector(),
+  //       ));
+
+  //   // return Padding(
+  //   //     padding: EdgeInsets.only(top: 20, bottom: 10),
+  //   //     child: Image.network(receivedAnimal.imageURL,
+  //   //         height: 250, width: 200, fit: BoxFit.fitWidth));
+  // }
+
+  Widget imageDisplaySelector() {
+    if (_imageLoading) {
+      return SizedBox(
+        height: 250,
+        width: 250,
+        child: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (receivedAnimal.imageURL == null) {
+      return SizedBox(
+        height: 250,
+        width: 250,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.image_search, size: 100),
+            Text('Select an Image'),
+          ],
+        ),
+      );
+    }
+    return Column(
+      children: [
+        SizedBox(
+          height: 250,
+          width: 250,
+          child: CachedNetworkImage(
+              placeholder: (_, __) =>
+                  Center(child: CircularProgressIndicator()),
+              imageUrl: receivedAnimal.imageURL,
+              fit: BoxFit.cover),
+        ),
+        Text('Tap on Image to Edit')
+      ],
+    );
   }
 
   Widget animalNameField(BuildContext context) {

--- a/lib/screens/add_pet_screen.dart
+++ b/lib/screens/add_pet_screen.dart
@@ -35,6 +35,8 @@ class _AddPetScreenState extends State<AddPetScreen> {
   // }
 
   void getImageUrl() async {
+    _imageLoading = true;
+    setState(() {});
     receivedAnimal.imageURL = await retrieveImageUrl();
     _imageLoading = false;
     setState(() {});

--- a/lib/screens/animal_inventory_screen.dart
+++ b/lib/screens/animal_inventory_screen.dart
@@ -35,6 +35,7 @@ class AnimalInventoryScreen extends StatelessWidget {
         StreamProvider<UserFavorites>(
           create: (_) => locator<AppUserService>().favoritesOnDataChange(),
           initialData: UserFavorites.initial(),
+          catchError: (_, __) => UserFavorites.initial(),
         ),
       ],
       child: Scaffold(

--- a/lib/screens/favorite_screen.dart
+++ b/lib/screens/favorite_screen.dart
@@ -24,6 +24,7 @@ class FavoriteScreen extends StatelessWidget {
     return StreamProvider<UserFavorites>(
       create: (_) => locator<AppUserService>().favoritesOnDataChange(),
       initialData: UserFavorites.initial(),
+      catchError: (_, __) => UserFavorites.initial(),
       child: Scaffold(
         appBar: AppBar(
           centerTitle: true,

--- a/lib/screens/news_screen.dart
+++ b/lib/screens/news_screen.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -96,7 +97,10 @@ class _NewsScreenState extends State<NewsScreen> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Container(child: Image.network('${post.imageUrl}')),
+            Container(
+                child: CachedNetworkImage(
+              imageUrl: post.imageUrl,
+            )),
             ListTile(
                 title: addPadding(
                   Text(
@@ -152,12 +156,12 @@ class _NewsScreenState extends State<NewsScreen> {
   }
 
   Widget deleteIcon(NewsItem post, BuildContext context) {
-  return IconButton(
-      icon: Icon(Icons.delete),
-      tooltip: 'Remove post',
-      onPressed: () {
-        showMyDialog('newsPost', post, context);
-      });
+    return IconButton(
+        icon: Icon(Icons.delete),
+        tooltip: 'Remove post',
+        onPressed: () {
+          showMyDialog('newsPost', post, context);
+        });
   }
 
   Widget shareIcon(NewsItem post) {

--- a/lib/services/app_user_service.dart
+++ b/lib/services/app_user_service.dart
@@ -54,7 +54,10 @@ class AppUserService {
   }
 
   Stream<UserFavorites> favoritesOnDataChange() {
-    return _users.doc(firebaseAuth.currentUser.uid).snapshots().map((userDoc) {
+    return _users
+        .doc(firebaseAuth?.currentUser?.uid)
+        ?.snapshots()
+        ?.map((userDoc) {
       if (userDoc == null) {
         return UserFavorites.initial();
       }

--- a/lib/services/image_service.dart
+++ b/lib/services/image_service.dart
@@ -3,6 +3,10 @@ import 'package:firebase_storage/firebase_storage.dart';
 import 'package:image_picker/image_picker.dart';
 
 //Reference for ImageServices Code: https://dev.to/rrtutors/upload-image-to-firebase-storage-flutter-android-ios-3f35
+class ImageService {
+  ImageService();
+}
+
 Future<String> retrieveImageUrl() async {
   final picker = ImagePicker();
   String imageUrl = "";

--- a/lib/widgets/admin_drawer.dart
+++ b/lib/widgets/admin_drawer.dart
@@ -112,8 +112,8 @@ class AdminDrawer extends StatelessWidget {
 */
 
   void logout(BuildContext context) async {
-    await locator<AppUserService>().firebaseAuth.signOut();
     Navigator.of(context).popUntil((route) => route.isFirst);
     Navigator.of(context).pushReplacementNamed(LandingScreen.routeName);
+    await locator<AppUserService>().firebaseAuth.signOut();
   }
 }

--- a/lib/widgets/user_drawer.dart
+++ b/lib/widgets/user_drawer.dart
@@ -103,8 +103,8 @@ class UserDrawer extends StatelessWidget {
   }
 
   void logout(BuildContext context) async {
-    await locator<AppUserService>().firebaseAuth.signOut();
     Navigator.of(context).popUntil((route) => route.isFirst);
     Navigator.of(context).pushReplacementNamed(LandingScreen.routeName);
+    await locator<AppUserService>().firebaseAuth.signOut();
   }
 }


### PR DESCRIPTION
Modify AddPetScreen so that the add (or edit) Animal screen appears before the imagePicker runs. This way, when users want to edit a pet, they are not required to pick a new image (but still can choose one if they want).